### PR TITLE
Separates configuration settings from code. 

### DIFF
--- a/app/assets/javascripts/analytics/analytics.js
+++ b/app/assets/javascripts/analytics/analytics.js
@@ -3,6 +3,13 @@
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-ga('create', 'UA-21109958-7', 'crowdint.com');
-ga('send', 'pageview');
+$.ajax({
+  url: '/analytics',
+  success: function(keys) {
+    if (keys.id) {
+      ga('create', keys.id, keys.domain);
+      ga('send', 'pageview');
+    }
+  }
+});
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,12 @@
+class SettingsController < ApplicationController
+  ANALYTICS_KEYS = {
+    id: Prdashboard::Application.config.analytics_id,
+    domain: Prdashboard::Application.config.analytics_domain
+  }
+
+  def analytics_keys
+    render json: ANALYTICS_KEYS, status: :ok
+  end
+
+end
+

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -1,0 +1,3 @@
+Prdashboard::Application.config.analytics_id = Rails.env.production? ? ENV['ANALYTICS_ID'] : nil
+Prdashboard::Application.config.analytics_domain = Rails.env.production? ? ENV['ANALYTICS_DOMAIN'] : nil
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Prdashboard::Application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/signout', to: 'sessions#destroy', as: :signout
   get '/dashboard', to: 'dashboard#index', as: :dashboard
+  get '/analytics', to: 'settings#analytics_keys'
 
 end
 


### PR DESCRIPTION
The analytics keys now should be set on ENV variables.

I chose this way instead of a js.erb file because I have had the problem that ENV variables are not available on asset precompiling at Heroku.

Any suggestion is welcome.
