### PR TITLE
Add fix for Travis build problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.1
+  - 2.1.1p76
 before_script:
   - "export SECRET_TOKEN='869ee827f9b463e63e052173c4ecd0ecc129645bbb2ca4b21ff1998303d54e079fc392f6c9bba2339adf86c06ea247a9086bc353ad7220c56c5af587b1a6946b'"
   - "cp config/database.yml.postgresql config/database.yml"
@@ -13,4 +13,3 @@ before_script:
 
 script:
   - "bundle exec rake"
-


### PR DESCRIPTION
This adds some config keys to use the now deprecated trusty image when building in Travis, as explained in this [blog post](https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch). 

In order to stop using the deprecated image we need to upgrade everything to at least ruby 2.1.10, since that's now the oldest ruby supported in the current trusty image.